### PR TITLE
Feature/c header and example logger

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,17 @@ INTERPOSE_C(void*, malloc, (size_t sz), (sz)) {
 }
 ```
 
+For interposing functions returning `void`, the macro `INTERPOSE_C_VOID()` is provided:
+
+```c
+INTERPOSE_C_VOID(free, (void* p), (p)) {
+  fprintf(stderr, "Caught a call to free()\n");
+  Real__free(p);
+}
+```
+
+Using `INTERPOSE_C(void, <remaining arguments...>)` may compile, but expands to code that violates constraint #1 of C99 and C11 "6.8.6.4 The `return` statement".
+
 There is an example library in `examples/logger` that intercepts calls to `malloc`, `free`, `calloc`, and `realloc`. This library tracks the number of bytes allocated and freed by the program, and prints allocation stats just before the program exits.
 
 ## Copyright & License

--- a/README.md
+++ b/README.md
@@ -12,6 +12,15 @@ INTERPOSE(malloc)(size_t sz) {
 
 This line declares a replacement function for `malloc` that logs the result, then passes the call on to the real `malloc` implementation. For this to work, the `malloc` symbol must be defined (by including `stdlib.h`). The replacement function is type-checked against the declared function, so compilation will fail if you try to replace `malloc` with a function that takes an `int` parameter. This helps prevent accidental type mismatch errors, but you can explicitly bypass this requirement by declaring `malloc` yourself instead of including the system-wide declaration.
 
+A C-only version is provided in `interpose.h`, differing in the name of the macro, the arguments passed to it, and the constructed name of the original function:
+
+```c
+INTERPOSE_C(void*, malloc, (size_t sz), (sz)) {
+  fprintf(stderr, "Caught a call to malloc(%zu)\n", sz);
+  return Real__malloc(sz);
+}
+```
+
 There is an example library in `examples/logger` that intercepts calls to `malloc`, `free`, `calloc`, and `realloc`. This library tracks the number of bytes allocated and freed by the program, and prints allocation stats just before the program exits.
 
 ## Copyright & License

--- a/README.md
+++ b/README.md
@@ -12,6 +12,12 @@ INTERPOSE(malloc)(size_t sz) {
 
 This line declares a replacement function for `malloc` that logs the result, then passes the call on to the real `malloc` implementation. For this to work, the `malloc` symbol must be defined (by including `stdlib.h`). The replacement function is type-checked against the declared function, so compilation will fail if you try to replace `malloc` with a function that takes an `int` parameter. This helps prevent accidental type mismatch errors, but you can explicitly bypass this requirement by declaring `malloc` yourself instead of including the system-wide declaration.
 
+## Example and Manual Test
+
+There is an example library in `examples/logger` that intercepts calls to `malloc`, `free`, `calloc`, and `realloc`. This library tracks the number of bytes allocated and freed by the program, and prints allocation stats just before the program exits.
+
+## C Version
+
 A C-only version is provided in `interpose.h`, differing in the name of the macro, the arguments passed to it, and the constructed name of the original function:
 
 ```c
@@ -31,8 +37,6 @@ INTERPOSE_C_VOID(free, (void* p), (p)) {
 ```
 
 Using `INTERPOSE_C(void, <remaining arguments...>)` may compile, but expands to code that violates constraint #1 of C99 and C11 "6.8.6.4 The `return` statement".
-
-There is an example library in `examples/logger` that intercepts calls to `malloc`, `free`, `calloc`, and `realloc`. This library tracks the number of bytes allocated and freed by the program, and prints allocation stats just before the program exits.
 
 ## Copyright & License
 MIT License

--- a/README.md
+++ b/README.md
@@ -16,6 +16,8 @@ This line declares a replacement function for `malloc` that logs the result, the
 
 There is an example library in `examples/logger` that intercepts calls to `malloc`, `free`, `calloc`, and `realloc`. This library tracks the number of bytes allocated and freed by the program, and prints allocation stats just before the program exits.
 
+Invoking `make test` in the mentioned directory will build and use the C++ version of the example interposition library, then run the test program with that library preloaded. Invoking `make test_c` will use the C version of the library instead.
+
 ## C Version
 
 A C-only version is provided in `interpose.h`, differing in the name of the macro, the arguments passed to it, and the constructed name of the original function:

--- a/examples/logger/Makefile
+++ b/examples/logger/Makefile
@@ -1,4 +1,5 @@
 CXX := clang++
+CC := clang
 
 ifeq ($(shell uname -s),Darwin)
 SHLIB_SUFFIX := dylib
@@ -9,20 +10,27 @@ else
 SHLIB_SUFFIX := so
 PRELOAD_VAR  := LD_PRELOAD
 CXXLIB       := $(CXX) -shared -fPIC -Wl,-soname,interposer.so
+CCLIB        := $(CC) -shared -fPIC
 endif
 
 all: logger.$(SHLIB_SUFFIX)
 
 clean:
-	@rm -f logger.$(SHLIB_SUFFIX) testprog
+	@rm -f logger.$(SHLIB_SUFFIX) logger_c.$(SHLIB_SUFFIX) testprog
 
 logger.$(SHLIB_SUFFIX): logger.cc ../../include/interpose.hh
 	$(CXXLIB) -I../../include --std=c++11 -o $@ $< -ldl
+
+logger_c.$(SHLIB_SUFFIX): logger.c ../../include/interpose.h
+	$(CCLIB) -I../../include --std=c99 -o $@ $< -ldl
 
 testprog: testprog.cc
 	$(CXX) --std=c++11 -o $@ $<
 
 test: testprog logger.$(SHLIB_SUFFIX)
 	$(PRELOAD_VAR)=./logger.$(SHLIB_SUFFIX) ./testprog
+
+test_c: testprog logger_c.$(SHLIB_SUFFIX)
+	$(PRELOAD_VAR)=./logger_c.$(SHLIB_SUFFIX) ./testprog
 
 .PHONY: all clean test

--- a/examples/logger/Makefile
+++ b/examples/logger/Makefile
@@ -4,8 +4,10 @@ CC := clang
 ifeq ($(shell uname -s),Darwin)
 SHLIB_SUFFIX := dylib
 PRELOAD_VAR  := DYLD_INSERT_LIBRARIES
-CXXLIB       := $(CXX) -shared -fPIC -compatibility_version 1 -current_version 1 \
-                        -dynamiclib
+DARWIN_DYLIB_FLAGS := -shared -fPIC -compatibility_version 1 -current_version 1 \
+                      -dynamiclib
+CXXLIB       := $(CXX) $(DARWIN_DYLIB_FLAGS)
+CCLIB        := $(CC) $(DARWIN_DYLIB_FLAGS)
 else
 SHLIB_SUFFIX := so
 PRELOAD_VAR  := LD_PRELOAD
@@ -13,7 +15,7 @@ CXXLIB       := $(CXX) -shared -fPIC -Wl,-soname,interposer.so
 CCLIB        := $(CC) -shared -fPIC
 endif
 
-all: logger.$(SHLIB_SUFFIX)
+all: logger.$(SHLIB_SUFFIX) logger_c.$(SHLIB_SUFFIX)
 
 clean:
 	@rm -f logger.$(SHLIB_SUFFIX) logger_c.$(SHLIB_SUFFIX) testprog

--- a/examples/logger/README.md
+++ b/examples/logger/README.md
@@ -1,4 +1,6 @@
 # Interpose Example: Logger
-This simple interposition example logs calls to `malloc`, `free`, `calloc`, `realloc`, and `exit`. The makefile also includes a simple test program that you can run with the logger preloaded by typing `make test`.
+This simple interposition example logs calls to `malloc`, `free`, `calloc`, `realloc`, and `exit`. The makefile also includes a simple test program that you can run with the logger preloaded by typing `make test`. The logger is implemented in [`logger.cc`](logger.cc).
+
+The C version of the interposition macro is exercised by typing `make test_c`, with the corresponding logger being implemented in [`logger.c`](logger.c).
 
 The logging code is fairly straightforward: each function is interposed-on with a replacement that logs the call and passes it along to the real implementation. The one complication is `calloc`, which includes a check for recursive calls. On Linux, `calloc` is called during dynamic library loading, but resolving the real `calloc` implementation will trigger this loading leading to an infinite recursive loop. However, if the replacement `calloc` returns `NULL` when called recursively, the dynamic linker will use an internal memory allocator instead.

--- a/examples/logger/logger.c
+++ b/examples/logger/logger.c
@@ -1,4 +1,6 @@
-#define _GNU_SOURCE
+#if !defined(__APPLE__)
+# define _GNU_SOURCE
+#endif
 
 #include <stdint.h>
 #include <stdio.h>

--- a/examples/logger/logger.c
+++ b/examples/logger/logger.c
@@ -1,0 +1,68 @@
+#define _GNU_SOURCE
+
+#include <stdint.h>
+#include <stdio.h>
+#include <stdlib.h>
+
+#include <interpose.h>
+
+#if defined(__APPLE__)
+#include <malloc/malloc.h>
+#define malloc_usable_size malloc_size
+#elif defined(__linux__)
+#include <malloc.h>
+#endif
+
+#define START_COLOR "\033[01;33m"
+#define END_COLOR "\033[0m"
+
+size_t allocated_bytes = 0;
+size_t freed_bytes = 0;
+
+INTERPOSE_C(void*, malloc, (size_t sz), (sz)) {
+  void* result = Real__malloc(sz);
+  allocated_bytes += malloc_usable_size(result);
+  return result;
+}
+
+INTERPOSE_C(void, free, (void* p), (p)) {
+  freed_bytes += malloc_usable_size(p);
+  Real__free(p);
+}
+
+INTERPOSE_C(void*, calloc, (size_t n, size_t sz), (n, sz)) {
+  void* result = Real__calloc(n, sz);
+  allocated_bytes += malloc_usable_size(result);
+  return result;
+}
+
+INTERPOSE_C(void*, realloc, (void* p, size_t sz), (p, sz)) {
+  size_t old_size = malloc_usable_size(p);
+  void* result = Real__realloc(p, sz);
+  size_t new_size = malloc_usable_size(p);
+
+  if(result == p) {
+    if(new_size > old_size) allocated_bytes += new_size - old_size;
+    else freed_bytes = old_size - new_size;
+  } else {
+    freed_bytes += old_size;
+    allocated_bytes += new_size;
+  }
+
+  return result;
+}
+
+INTERPOSE_C(void, exit, (int status), (status)) {
+  fprintf(stderr, START_COLOR);
+  fprintf(stderr, "\n\nProgram Allocation Stats\n");
+  fprintf(stderr, "  allocated %zu bytes\n", allocated_bytes);
+  fprintf(stderr, "      freed %zu bytes\n", freed_bytes);
+  if(allocated_bytes >= freed_bytes) {
+    fprintf(stderr, "     leaked %zu bytes\n", allocated_bytes - freed_bytes);
+  } else {
+    fprintf(stderr, "      freed %zu extra bytes\n", freed_bytes - allocated_bytes);
+  }
+  fprintf(stderr, END_COLOR);
+
+  Real__exit(status);
+}

--- a/examples/logger/logger.c
+++ b/examples/logger/logger.c
@@ -25,7 +25,7 @@ INTERPOSE_C(void*, malloc, (size_t sz), (sz)) {
   return result;
 }
 
-INTERPOSE_C(void, free, (void* p), (p)) {
+INTERPOSE_C_VOID(free, (void* p), (p)) {
   freed_bytes += malloc_usable_size(p);
   Real__free(p);
 }
@@ -52,7 +52,7 @@ INTERPOSE_C(void*, realloc, (void* p, size_t sz), (p, sz)) {
   return result;
 }
 
-INTERPOSE_C(void, exit, (int status), (status)) {
+INTERPOSE_C_VOID(exit, (int status), (status)) {
   fprintf(stderr, START_COLOR);
   fprintf(stderr, "\n\nProgram Allocation Stats\n");
   fprintf(stderr, "  allocated %zu bytes\n", allocated_bytes);

--- a/include/interpose.h
+++ b/include/interpose.h
@@ -1,0 +1,41 @@
+/*
+ * MIT License
+ * Based on interpose.hh which is copyright (c) 2017 Charlie Curtsinger
+ */
+
+#if !defined(__INTERPOSE_H)
+#define __INTERPOSE_H
+
+#include <stdint.h>
+
+#include <dlfcn.h>
+
+#if defined(__ELF__)
+
+#if !defined _GNU_SOURCE
+# error Must define _GNU_SOURCE for RTLD_NEXT to be available.
+#endif
+
+// The C version of the interposition macro differs from that of the C++ version: the user
+// has to provide the argument type-and-name list as a macro argument (instead of postfixing
+// it to the macro invocation), and to redundantly provide the list of just argument names,
+// which must match those in the type-and-name list.
+#define INTERPOSE_C(RETURN_TYPE, NAME, ARG_TYPE_AND_NAME_LIST, ARG_NAME_LIST) \
+  static RETURN_TYPE Real__##NAME ARG_TYPE_AND_NAME_LIST { \
+    static __typeof__(NAME)* real_##NAME; \
+    __typeof__(NAME)* func = __atomic_load_n(&real_##NAME, __ATOMIC_CONSUME); \
+    if(!func) { \
+      func = (__typeof__(NAME)*)( \
+        (uintptr_t)(dlsym(RTLD_NEXT, #NAME))); \
+      __atomic_store_n(&real_##NAME, func, __ATOMIC_RELEASE); \
+    } \
+    return func ARG_NAME_LIST; \
+  } \
+  extern __typeof__(NAME) NAME __attribute__((weak, alias("__interpose_" #NAME))); \
+  extern RETURN_TYPE __interpose_##NAME ARG_TYPE_AND_NAME_LIST
+
+#else
+# error Unsupported platform.
+#endif
+
+#endif


### PR DESCRIPTION
This pull request adds a C version of the interposition macro, together with accompanying example logger / test (`make test_c`) and documentation. The macro naturally ends up being more verbose and clumsy to use.

This is useful in scenarios where it is undesirable that the generated SO has dependencies on the C++ standard library, for example because the target might have an older version of it and one does not want to risk dynamic load time incompatibilities. \
Sure, one could use `-static-libstdc++`, but in that case it may be desirable that the generated SO is as small as possible. So, one would always have to watch out whether using some feature pulls in calls to the library (i.e. is not completely inlineable). \
In short, using C is nice when one desires minimalism and C++ is unnecessary for the purposes of implementing the interposition code.