### PR TITLE
Fix interpose compilation issues for functions marked noexcept

### DIFF
--- a/include/interpose.hh
+++ b/include/interpose.hh
@@ -23,6 +23,10 @@ template<typename R, typename... Args> struct fn_info<R(Args...)> {
   using ret_type = R;
 };
 
+/// Starting with C++17, some library implementations of malloc are marked noexcept.
+template<typename R, typename... Args>
+struct fn_info<R(Args...) noexcept> : fn_info<R(Args...)> {};
+
 #if defined(__ELF__)
 
 /**


### PR DESCRIPTION
This fixes issue discussed in #5. It seems that starting with C++17, some standard library implementations mark `malloc` as `noexcept`.

As per discussion found [here](https://stackoverflow.com/questions/45965452/c-remove-noexcept-from-decltype-returned-type), this should cover most use cases, possibly with some edge case exceptions.